### PR TITLE
Allow / in strings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, x86, aarch64]
-        version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         target: [x64, x86]
-        version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
-        version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,7 +1142,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "portforward"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.7.1 (2024-12-15)
+------------------
+* Allow "/" in strings
+* Drop support for Python 3.8
+
 0.7.0 (2024-10-18)
 ------------------
 * Allow binding to a local random free port

--- a/README.rst
+++ b/README.rst
@@ -40,11 +40,11 @@ Wheels are available for:
 
 with Python versions:
 
-* 3.8
 * 3.9
 * 3.10
 * 3.11
 * 3.12
+* 3.13
 
 **Requirements for installation from source**
 

--- a/python/portforward/__init__.py
+++ b/python/portforward/__init__.py
@@ -199,9 +199,6 @@ def _validate_str(arg_name, arg) -> str:
     if len(arg) == 0:
         raise ValueError(f"{arg_name} cannot be an empty str")
 
-    if "/" in arg:
-        raise ValueError(f"{arg_name} contains illegal character '/'")
-
     return arg
 
 
@@ -252,8 +249,5 @@ def _kube_context(context):
 
     if not isinstance(context, str):
         raise ValueError(f"kube_context={context} is not a valid str")
-
-    if "/" in context:
-        raise ValueError("kube_context contains illegal character '/'")
 
     return context

--- a/tests/test_portforward.py
+++ b/tests/test_portforward.py
@@ -157,12 +157,10 @@ def test_portforward_from_port_zero_assigns_port(kind_cluster: KindCluster):
     [
         # Namespace
         ("", "web", 9000, 80),
-        ("/test", "web", 9000, 80),
         (1337, "web", 9000, 80),
         (None, "web", 9000, 80),
         # Pod name
         ("test", "", 9000, 80),
-        ("test", "web/", 9000, 80),
         ("test", 1337, 9000, 80),
         ("test", None, 9000, 80),
         # From port


### PR DESCRIPTION
This PR drops the validation if a string (like kube context or namespace) contains a `/`.