### PR TITLE
Bring build back to green: PyO3 0.24, new async runtimes, CI fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,6 @@ on:
       - '*'
   pull_request:
   workflow_dispatch:
-    
-env:
-      PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
 
 permissions:
   contents: read
@@ -51,6 +48,28 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
+          before-script-linux: |
+            # --- s390x baseline z10 ---------------------------------
+            if [[ "${{ matrix.platform.target }}" == "s390x" ]]; then
+                export CFLAGS="-march=z10 -mzarch"
+                export CXXFLAGS="$CFLAGS"
+                export RUSTFLAGS="-C target-cpu=z10"
+            fi
+            # --------------------------------------------------------
+            
+            # If we're running on rhel centos, install needed packages.
+            if command -v yum &> /dev/null; then
+                yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic
+            
+                # If we're running on i686 we need to symlink libatomic
+                # in order to build openssl with -latomic flag.
+                if [[ ! -d "/usr/lib64" ]]; then
+                    ln -s /usr/lib/libatomic.so.1 /usr/lib/libatomic.so
+                fi
+            else
+                # If we're running on debian-based system.
+                apt update -y && apt-get install -y libssl-dev openssl pkg-config
+            fi
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -74,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: 3.x
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -82,6 +101,28 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
+          before-script-linux: |
+            # --- s390x baseline z10 ---------------------------------
+            if [[ "${{ matrix.platform.target }}" == "s390x" ]]; then
+                export CFLAGS="-march=z10 -mzarch"
+                export CXXFLAGS="$CFLAGS"
+                export RUSTFLAGS="-C target-cpu=z10"
+            fi
+            # --------------------------------------------------------
+            
+            # If we're running on rhel centos, install needed packages.
+            if command -v yum &> /dev/null; then
+                yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic
+            
+                # If we're running on i686 we need to symlink libatomic
+                # in order to build openssl with -latomic flag.
+                if [[ ! -d "/usr/lib64" ]]; then
+                    ln -s /usr/lib/libatomic.so.1 /usr/lib/libatomic.so
+                fi
+            else
+                # If we're running on debian-based system.
+                apt update -y && apt-get install -y libssl-dev openssl pkg-config
+            fi
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -329,7 +329,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -340,7 +340,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -374,7 +374,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -551,7 +551,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "home"
@@ -907,7 +907,7 @@ checksum = "d076d5b64a7e2fe6f0743f02c43ca4a6725c0f904203bfe276a5b3e793103605"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1050,7 +1050,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1206,7 +1206,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1322,7 +1322,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1353,7 +1353,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1403,7 +1403,8 @@ dependencies = [
  "once_cell",
  "openssl",
  "pyo3",
- "pyo3-asyncio",
+ "pyo3-async-runtimes",
+ "pyo3-ffi",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1430,15 +1431,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -1447,35 +1448,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3-asyncio"
-version = "0.20.0"
+name = "pyo3-async-runtimes"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea6b68e93db3622f3bb3bf363246cf948ed5375afe7abff98ccbdd50b184995"
+checksum = "dd0b83dc42f9d41f50d38180dad65f0c99763b65a3ff2a81bf351dd35a1df8bf"
 dependencies = [
  "futures",
  "once_cell",
  "pin-project-lite",
  "pyo3",
- "pyo3-asyncio-macros",
+ "pyo3-async-runtimes-macros",
  "tokio",
 ]
 
 [[package]]
-name = "pyo3-asyncio-macros"
-version = "0.20.0"
+name = "pyo3-async-runtimes-macros"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c467178e1da6252c95c29ecf898b133f742e9181dca5def15dc24e19d45a39"
+checksum = "cf103ba4062fbb1e8022d9ed9b9830fbab074b2db0a0496c78e45a62f4330bcd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1483,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1493,27 +1494,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
 dependencies = [
  "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1726,7 +1727,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1807,7 +1808,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1818,7 +1819,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1922,17 +1923,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
@@ -1950,9 +1940,9 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "thiserror"
@@ -1980,7 +1970,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1991,7 +1981,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2020,7 +2010,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2137,7 +2127,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2189,7 +2179,7 @@ checksum = "60d8d828da2a3d759d3519cdf29a5bac49c77d039ad36d0782edadbf9cd5415b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2298,7 +2288,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2320,7 +2310,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2457,7 +2447,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2468,7 +2458,7 @@ checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,6 @@ ws = ["kube/ws"]
 latest = ["k8s-openapi/v1_32"]
 
 [dependencies]
-pyo3 = "^0.20.0"
-pyo3-asyncio = { version = "^0.20.0", features = ["attributes", "tokio-runtime"] }
 once_cell = "1.21.3"
 typed-builder = "0.21.0"
 futures = "0.3.31"
@@ -35,3 +33,6 @@ kube = { version = "^0.99.0", default-features = false, features = ["admission"]
 kube-derive = { version = "^0.99.0", default-features = false } # only needed to opt out of schema
 k8s-openapi = { version = "0.24.0", default-features = false }
 openssl = { version = "0.10.52", features = ["vendored"] }
+pyo3-async-runtimes = { version = "=0.24.0", features = ["attributes", "tokio-runtime"] }
+pyo3-ffi = "0.24.1"
+pyo3 = "0.24.1"

--- a/README.rst
+++ b/README.rst
@@ -34,9 +34,11 @@ Installation
 
 Wheels are available for:
 
-* Windows (architectures: x64, x86)
-* MacOS X (architectures: x86_64, aarch64)
-* Linux (architectures: x86_64, x86, aarch64)
+* **Windows** (architectures: ``x64``, ``x86``)
+* **macOS**   (architectures: ``x86_64``, ``aarch64``)
+* **Linux**   (architectures: ``x86_64``, ``x86``, ``aarch64``, ``armv7``, ``s390x``, ``ppc64le``)
+
+Musllinux wheels (Alpine‑compatible) are provided for ``x86_64``, ``x86``, ``aarch64`` and ``armv7``.
 
 with Python versions:
 

--- a/misc/before_script_linux.sh
+++ b/misc/before_script_linux.sh
@@ -1,0 +1,21 @@
+# --- s390x baseline z10 ---------------------------------
+if [[ "${{ matrix.platform.target }}" == "s390x" ]]; then
+    export CFLAGS="-march=z10 -mzarch"
+    export CXXFLAGS="$CFLAGS"
+    export RUSTFLAGS="-C target-cpu=z10"
+fi
+# --------------------------------------------------------
+
+# If we're running on rhel centos, install needed packages.
+if command -v yum &> /dev/null; then
+    yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic
+
+    # If we're running on i686 we need to symlink libatomic
+    # in order to build openssl with -latomic flag.
+    if [[ ! -d "/usr/lib64" ]]; then
+        ln -s /usr/lib/libatomic.so.1 /usr/lib/libatomic.so
+    fi
+else
+    # If we're running on debian-based system.
+    apt update -y && apt-get install -y libssl-dev openssl pkg-config
+fi

--- a/misc/generate_release_config.sh
+++ b/misc/generate_release_config.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Configuration
+BEFORE_SCRIPT_FILE="misc/before_script_linux.sh"
+
+# Generate base CI file
+maturin generate-ci github > .github/workflows/release.yml
+
+# Validate input file
+if [ ! -f "$BEFORE_SCRIPT_FILE" ]; then
+  echo "Error: Input file $BEFORE_SCRIPT_FILE not found"
+  exit 1
+fi
+
+# Format injection content with proper YAML indentation
+INSERT_TEXT="          before-script-linux: |"
+while IFS= read -r line; do
+  INSERT_TEXT="$INSERT_TEXT\n            $line"
+done < "$BEFORE_SCRIPT_FILE"
+
+# Create temporary file for processing
+TMP_FILE=$(mktemp)
+
+# Process file line-by-line and inject content after each "manylinux:" match
+while IFS= read -r line; do
+  echo "$line" >> "$TMP_FILE"
+  
+  if echo "$line" | grep -q "manylinux:"; then
+    echo -e "$INSERT_TEXT" >> "$TMP_FILE"
+  fi
+done < .github/workflows/release.yml
+
+# Replace original file with processed version
+mv "$TMP_FILE" .github/workflows/release.yml
+
+# Update workflow name - handle BSD vs GNU sed differently
+if sed --version 2>/dev/null | grep -q GNU; then
+  # GNU sed
+  sed -i -e 's/^name: CI$/name: Release/' .github/workflows/release.yml
+else
+  # BSD sed (macOS)
+  sed -i '' -e 's/^name: CI$/name: Release/' .github/workflows/release.yml
+fi
+
+echo "Done! CI workflow updated with external content."


### PR DESCRIPTION
### Dependency updates
- **PyO3** has been upgraded to **0.24.1**  
- The deprecated **`pyo3‑asyncio` 0.20.x** wrapper has been replaced with **`pyo3‑async‑runtimes` 0.24.0**

---

### Code adjustments
The latest PyO3 introduces `Py<…>` and `Bound` wrapper types and moves several helper methods onto them. To adapt:

1. Functions now return `Py<PyAny>`
2. The `#[pymodule]` initializer takes `&Bound<PyModule>`
3. A few calls were tweaked to use the new wrappers (e.g., returning `()` for Python `None`)

With these changes everything compiles again and the port‑forward extension works as before.

---

### Reproducible CI
To eliminate manual edits in **`release.yml`** I added `./misc/generate_release_config.sh`, which:

1. Generates the default *release.yml* via `maturin`
2. Renames the workflow from **“CI”** to **“Release”**
3. Patches two issues:
   - Adds the missing Perl module needed by OpenSSL
   - Works around the OpenSSL 3.4.1 build failure on *s390x*

This keeps the workflow fully regenerable with a single command.

---

### References
- <https://github.com/sfackler/rust-openssl/issues/2036#issuecomment-1724324145>  
- <https://github.com/openssl/openssl/issues/27323>

---

* closes #47
* closes #48